### PR TITLE
Add compatibility with JDK 10+ bytecode

### DIFF
--- a/highwheel-parser/pom.xml
+++ b/highwheel-parser/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-			<version>6.0</version>
+			<version>7.0</version>
 		</dependency>
 		
 	</dependencies>

--- a/highwheel-parser/src/test/java/org/pitest/highwheel/bytecodeparser/ClassPathParserTest.java
+++ b/highwheel-parser/src/test/java/org/pitest/highwheel/bytecodeparser/ClassPathParserTest.java
@@ -1,8 +1,8 @@
 package org.pitest.highwheel.bytecodeparser;
 
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.pitest.highwheel.classpath.AccessVisitor;
 import org.pitest.highwheel.classpath.ClasspathRoot;
 import org.pitest.highwheel.cycles.Filter;
@@ -53,7 +55,7 @@ public class ClassPathParserTest {
     when(this.filter.include(foo)).thenReturn(true);
     final InputStream is = Mockito.mock(InputStream.class);
     when(this.cp.getData(foo)).thenReturn(is);
-    when(is.read()).thenThrow(new IOException());
+    doThrow(new IOException()).when(is).read(any(), eq(0), anyInt());
     try {
       this.testee.parse(cp,this.v);
     } catch (final IOException ex) {


### PR DESCRIPTION
Highwheel uses ASM 6.0 which only supports bytecode created by JDK 9 and earlier. As a result, the highwheel-maven-plugin fails with the following exception when analysing classes compiled by JDK 10 and later:
```
Caused by: java.lang.IllegalArgumentException
    at org.pitest.highwheel.parser.asm.ClassReader.<init> (ClassReader.java:160)
    at org.pitest.highwheel.parser.asm.ClassReader.<init> (ClassReader.java:143)
    at org.pitest.highwheel.parser.asm.ClassReader.<init> (ClassReader.java:418)
    at org.pitest.highwheel.bytecodeparser.ClassPathParser.parseClass (ClassPathParser.java:42)
    at org.pitest.highwheel.bytecodeparser.ClassPathParser.parse (ClassPathParser.java:32)
    at org.pitest.highwheel.Highwheel.analyse (Highwheel.java:44)
    at org.pitest.highwheel.maven.AnalyseMojo.analyse (AnalyseMojo.java:48)
    at org.pitest.highwheel.maven.BaseMojo.execute (BaseMojo.java:78)
```
The `org.pitest.highwheel.parser.asm` package is the shaded ASM dependency.