### PR TITLE
ASM7 opcodes needed to parse Java 11 bytecode classes

### DIFF
--- a/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyClassVisitor.java
+++ b/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyClassVisitor.java
@@ -25,7 +25,7 @@ class DependencyClassVisitor extends ClassVisitor {
 
   public DependencyClassVisitor(final ClassVisitor visitor,
       final AccessVisitor typeReceiver, NameTransformer nameTransformer) {
-    super(Opcodes.ASM6, visitor);
+    super(Opcodes.ASM7, visitor);
     this.dependencyVisitor = filterOutJavaLangObject(typeReceiver);
     this.nameTransformer = nameTransformer;
   }

--- a/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyFieldVisitor.java
+++ b/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyFieldVisitor.java
@@ -15,7 +15,7 @@ public class DependencyFieldVisitor extends FieldVisitor {
 
   public DependencyFieldVisitor(final AccessPoint owner,
       final AccessVisitor typeReceiver) {
-    super(Opcodes.ASM6, null);
+    super(Opcodes.ASM7, null);
     this.typeReceiver = typeReceiver;
     this.parent = owner;
   }

--- a/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyMethodVisitor.java
+++ b/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencyMethodVisitor.java
@@ -17,7 +17,7 @@ class DependencyMethodVisitor extends MethodVisitor {
 
   public DependencyMethodVisitor(final AccessPoint owner,
       final AccessVisitor typeReceiver, NameTransformer nameTransformer) {
-    super(Opcodes.ASM6, null);
+    super(Opcodes.ASM7, null);
     this.typeReceiver = typeReceiver;
     this.parent = owner;
     this.nameTransformer = nameTransformer;

--- a/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencySignatureVisitor.java
+++ b/highwheel-parser/src/main/java/org/pitest/highwheel/bytecodeparser/DependencySignatureVisitor.java
@@ -15,7 +15,7 @@ public class DependencySignatureVisitor extends SignatureVisitor {
 
   public DependencySignatureVisitor(final AccessPoint owner,
       final AccessVisitor typeReceiver, AccessType type) {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
     this.typeReceiver = typeReceiver;
     this.parent = owner;
     this.type = type;


### PR DESCRIPTION
Prevents this Exception when parsing a Java 11 class:
```
Caused by: java.lang.UnsupportedOperationException: This feature requires ASM7
    at org.pitest.highwheel.parser.asm.ClassVisitor.visitNestHost (ClassVisitor.java:150)
    at org.pitest.highwheel.parser.asm.ClassReader.accept (ClassReader.java:541)
    at org.pitest.highwheel.parser.asm.ClassReader.accept (ClassReader.java:391)
    at org.pitest.highwheel.bytecodeparser.ClassPathParser.parseClass (ClassPathParser.java:45)
    at org.pitest.highwheel.bytecodeparser.ClassPathParser.parse (ClassPathParser.java:32)
    at org.pitest.highwheel.Highwheel.analyse (Highwheel.java:44)
    at org.pitest.highwheel.maven.AnalyseMojo.analyse (AnalyseMojo.java:48)
    at org.pitest.highwheel.maven.BaseMojo.execute (BaseMojo.java:78)
```